### PR TITLE
handle decoding errors more softly

### DIFF
--- a/regrippy/plugins/tasks.py
+++ b/regrippy/plugins/tasks.py
@@ -98,10 +98,10 @@ class RegistryAction(object):
     @staticmethod
     def from_binary(binary):
         name_len = int.from_bytes(binary[2:6], byteorder="little")
-        name = binary[6 : 6 + name_len].decode("utf-16-le")
+        name = binary[6 : 6 + name_len].decode("utf-16-le", errors="backslashreplace")
 
         offset = 6 + name_len
-        action_type = binary[offset : offset + 2].decode("ascii")
+        action_type = binary[offset : offset + 2].decode("ascii", errors="backslashreplace")
         cmd = None
         offset += 2
 
@@ -109,13 +109,13 @@ class RegistryAction(object):
             offset += 4
             cmd_len = int.from_bytes(binary[offset : offset + 4], byteorder="little")
             offset += 4
-            cmd = binary[offset : offset + cmd_len].decode("utf-16-le")
+            cmd = binary[offset : offset + cmd_len].decode("utf-16-le", errors="backslashreplace")
 
             offset += cmd_len
             args_len = int.from_bytes(binary[offset : offset + 4], byteorder="little")
             if args_len > 0:
                 offset += 4
-                args = binary[offset : offset + args_len].decode("utf-16-le")
+                args = binary[offset : offset + args_len].decode("utf-16-le", errors="backslashreplace")
                 cmd += " " + args
 
         return RegistryAction(name, cmd)


### PR DESCRIPTION
In some cases, UTF16 decoding errors may lead to a program abort. I'd prefer to have a more soft information about the failed characters, instead of simply a stack trace.

See also "Error handlers" in: <https://docs.python.org/3/library/codecs.html>