### PR TITLE
remove newlines from bodyfile output

### DIFF
--- a/regrippy/__init__.py
+++ b/regrippy/__init__.py
@@ -23,7 +23,10 @@ def mactime(
     return "|".join(
         [
             md5,
-            name,
+            # remove newlines from the name. There are cases where newlines
+            # occur in registry key names, but their occurance breaks the
+            # bodyfile format, so we escape them here
+            name.replace("\n", "\\n").replace("\r", "\\r"),
             str(inode),
             mode_as_string,
             str(uid),


### PR DESCRIPTION
We recently had a case where a registry hive contained a key with a newline in its name, which broke the bodyfile format. I think this fix could handle such cases.