### PR TITLE
tasks plugin: add support for additional Actions values

### DIFF
--- a/regrippy/plugins/shimcache.py
+++ b/regrippy/plugins/shimcache.py
@@ -20,8 +20,11 @@ class Plugin(BasePlugin):
 
         if not key:
             return
+        read_cache_results = read_cache(key.value("AppCompatCache").value())
+        if not read_cache_results:
+            return
 
-        for entry in read_cache(key.value("AppCompatCache").value()):
+        for entry in read_cache_results:
             res = PluginResult(key=key, value=None)
             res.custom["date"] = entry[0]
             if type(entry[2]) == bytes:


### PR DESCRIPTION
In the `Tasks` plugin: the `Actions` registry value is a binary blob, parsed by the `RegistryAction.from_binary()` method, which assumed a specific data format to parse. It choked when encountering unexpected values with errors like

`UnicodeDecodeError: 'utf-16-le' codec can't decode bytes in position 12-13: illegal UTF-16 surrogate`

This PR adds base support for another data format for `Actions` values.